### PR TITLE
feat: allow multiple statuses per contributor and persist data

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,14 +166,15 @@
                                 <button class="btn btn--secondary" id="bulkArchiveBtn">Archive Selected</button>
                             </div>
                         </div>
-                        
+
                         <div class="table-container">
                             <table class="contributors-table">
                                 <thead>
                                     <tr>
                                         <th><input type="checkbox" id="selectAll"></th>
                                         <th>Email</th>
-                                        <th>Status</th>
+                                        <th>Assignment</th>
+                                        <th>Result</th>
                                         <th>Date Added</th>
                                         <th>Date Assigned</th>
                                         <th>Date Completed</th>
@@ -223,7 +224,8 @@
                                 <thead>
                                     <tr>
                                         <th>Email</th>
-                                        <th>Status</th>
+                                        <th>Assignment</th>
+                                        <th>Result</th>
                                         <th>Date Added</th>
                                         <th>Date Assigned</th>
                                         <th>Date Completed</th>
@@ -258,7 +260,7 @@
                                 <thead>
                                     <tr>
                                         <th>Email</th>
-                                        <th>Final Status</th>
+                                        <th>Result</th>
                                         <th>Date Added</th>
                                         <th>Date Completed</th>
                                         <th>Date Archived</th>


### PR DESCRIPTION
## Summary
- allow contributors to track assignment and pass/fail simultaneously
- show assignment and result columns in UI tables
- persist contributor data to localStorage to keep progress across refreshes

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba03e630d8833286e4700608bd5b17