### PR TITLE
feat: add multi-project management with import/export

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,13 @@
             <div class="container">
                 <h1>GenAI Contributor Retraining Manager</h1>
                 <div class="header-actions">
+                    <div class="project-controls">
+                        <select id="projectSelect" class="form-control"></select>
+                        <button class="btn btn--outline btn--sm" id="addProjectBtn">➕ New</button>
+                        <button class="btn btn--outline btn--sm" id="exportProjectBtn">📤 Export</button>
+                        <button class="btn btn--outline btn--sm" id="importProjectBtn">📥 Import</button>
+                        <input type="file" id="importProjectFile" accept=".json" class="hidden">
+                    </div>
                     <button class="btn btn--outline btn--sm" id="exportCsvBtn">
                         📁 Export CSV
                     </button>

--- a/style.css
+++ b/style.css
@@ -769,6 +769,16 @@ select.form-control {
   gap: var(--space-8);
 }
 
+.project-controls {
+  display: flex;
+  gap: var(--space-8);
+  align-items: center;
+}
+
+.project-controls .form-control {
+  width: auto;
+}
+
 .nav-tabs {
   background-color: var(--color-surface);
   border-bottom: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- add project dropdown with buttons to create, import, and export projects
- persist multiple projects in localStorage and support switching between them
- style new project controls in header

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a0929848332ae7c118b2fef7b2b