### PR TITLE
Fix share link and ensure project deletion

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Scale Training/Webinar Status Manager</title>
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lz-string@1.5.0/libs/lz-string.min.js"></script>
 </head>
 <body>
     <div class="app">


### PR DESCRIPTION
## Summary
- compress project data and use URL fragments for reliable sharing
- load shared projects from URL hash on startup
- persist project state after deletion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba252c2d3483328031bebb01cf76b2