### PR TITLE
Fix shared project duplication and remove unused import/export controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -1391,10 +1391,13 @@ function initApp() {
     if (shared) {
         try {
             const data = decodeProjectData(shared);
-            let name = data.name || 'Shared Project';
-            if (appState.projectList.includes(name)) {
-                // If the project already exists, switch to it instead of creating a duplicate
-                appState.currentProject = name;
+            let name = (data.name || 'Shared Project').trim();
+            const existing = appState.projectList.find(
+                p => p.trim().toLowerCase() === name.toLowerCase()
+            );
+            if (existing) {
+                // Project already exists; switch to it instead of creating a copy
+                appState.currentProject = existing;
             } else {
                 appState.projectList.push(name);
                 appState.currentProject = name;
@@ -1606,11 +1609,8 @@ function initApp() {
     // Project controls
     const projectSelect = document.getElementById('projectSelect');
     const addProjectBtn = document.getElementById('addProjectBtn');
-    const exportProjectBtn = document.getElementById('exportProjectBtn');
-    const importProjectBtn = document.getElementById('importProjectBtn');
     const shareProjectBtn = document.getElementById('shareProjectBtn');
     const deleteProjectBtn = document.getElementById('deleteProjectBtn');
-    const importProjectFile = document.getElementById('importProjectFile');
 
     if (projectSelect) {
         projectSelect.addEventListener('change', (e) => {
@@ -1642,21 +1642,12 @@ function initApp() {
         });
     }
 
-    if (exportProjectBtn) {
-        exportProjectBtn.addEventListener('click', exportProject);
-    }
-
     if (shareProjectBtn) {
         shareProjectBtn.addEventListener('click', shareProject);
     }
 
     if (deleteProjectBtn) {
         deleteProjectBtn.addEventListener('click', deleteProject);
-    }
-
-    if (importProjectBtn && importProjectFile) {
-        importProjectBtn.addEventListener('click', () => importProjectFile.click());
-        importProjectFile.addEventListener('change', handleImportProject);
     }
     
     // Modal event listeners

--- a/index.html
+++ b/index.html
@@ -17,11 +17,8 @@
                     <div class="project-controls">
                         <select id="projectSelect" class="form-control"></select>
                         <button class="btn btn--outline btn--sm" id="addProjectBtn">➕ New</button>
-                        <button class="btn btn--outline btn--sm" id="exportProjectBtn">📤 Export</button>
-                        <button class="btn btn--outline btn--sm" id="importProjectBtn">📥 Import</button>
                         <button class="btn btn--outline btn--sm" id="shareProjectBtn">🔗 Share</button>
                         <button class="btn btn--outline btn--sm" id="deleteProjectBtn">🗑️ Delete</button>
-                        <input type="file" id="importProjectFile" accept=".json" class="hidden">
                     </div>
                     <button class="btn btn--outline btn--sm" id="exportCsvBtn">
                         📁 Export CSV


### PR DESCRIPTION
## Summary
- Prevent shared project links from creating duplicate entries by normalizing the project name before adding it to the list.
- Remove unused import and export project controls from the UI and initialization code.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba29e0a42883329099b347eb10acf8