### PR TITLE
Normalize outlier emails

### DIFF
--- a/app.js
+++ b/app.js
@@ -289,9 +289,10 @@ function validateEmail(email) {
 }
 
 function normalizeEmail(email) {
-    const [local, domain] = email.toLowerCase().split('@');
+    const [local, domain = ''] = email.toLowerCase().split('@');
     const normalizedLocal = local.replace(/\+outlier$/i, '');
-    return `${normalizedLocal}@${domain}`;
+    const normalizedDomain = domain.replace(/\+outlier$/i, '');
+    return `${normalizedLocal}@${normalizedDomain}`;
 }
 
 function dedupeOutlierContributors() {


### PR DESCRIPTION
## Summary
- Ensure email normalization strips trailing `+outlier` from both local and domain parts so addresses like `user@gmail.com+outlier` dedupe with the base address

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bb188c0c4483328a0db79f645e85a3